### PR TITLE
CS-252 Chore/프로메테우스 메트릭 수집

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -20,3 +20,15 @@ logging:
 
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health           # 애플리케이션 상태 확인
+          - prometheus       # 메트릭 데이터 노출
+
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -20,3 +20,16 @@ logging:
 
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health           # 애플리케이션 상태 확인
+          - info             # 애플리케이션 정보
+          - prometheus       # 메트릭 데이터 노출
+
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- `/actuator/...` 엔드포인트 활성화 및 모니터링 지표 노출 확인 완료
- `application-local.yaml`에 health, info, prometheus 노출 설정 추가
- dev 환경 기준으로 health 상세 정보는 `show-details: never`로 제한

`http://localhost:8080/actuator/prometheus` 접속 시 메트릭 노출 확인

![프로메테우스1](https://github.com/user-attachments/assets/4fc9bec5-3c61-4aca-b37b-206b34b40a11)

---

## 🔗 관련 이슈
- closes #16 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 개발 및 로컬 환경에서 Prometheus, health, info 관리 엔드포인트 접근이 가능해졌습니다.
  - health 엔드포인트의 상세 정보 표시 수준이 환경에 따라 다르게 설정되었습니다.

- **기타**
  - 내부 라이브러리 의존성 구성이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->