### PR TITLE
CS-309 feat/검색, 인기 검색어 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
 	// MSA
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation("org.testcontainers:elasticsearch:1.21.0")
+	testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
 	// DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// MSA
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/src/main/java/com/playus/searchservice/domain/common/adapter/TrendingKeywordAdapter.java
+++ b/src/main/java/com/playus/searchservice/domain/common/adapter/TrendingKeywordAdapter.java
@@ -1,0 +1,33 @@
+package com.playus.searchservice.domain.common.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class TrendingKeywordAdapter {
+
+    private static final String KEY_NAME = "TRENDING-KEYWORD";
+    private final RedisTemplate<String, String> trendingKeywordRedisTemplate;
+
+    public Boolean addKeyword(String keyword) {
+        return trendingKeywordRedisTemplate.opsForZSet().add(KEY_NAME, keyword, 1);
+    }
+
+    public Double scoreKeyword (String keyword) {
+        return trendingKeywordRedisTemplate.opsForZSet().incrementScore(KEY_NAME, keyword, 1);
+    }
+
+    public Boolean existsKeyword(String keyword) {
+        Double score = trendingKeywordRedisTemplate.opsForZSet().score(KEY_NAME, keyword);
+        return score != null;
+    }
+
+    public Set<ZSetOperations.TypedTuple<String>> getTop10Keywords() {
+        return trendingKeywordRedisTemplate.opsForZSet().reverseRangeWithScores(KEY_NAME, 0, 9);
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/common/feign/client/UserFeignClient.java
+++ b/src/main/java/com/playus/searchservice/domain/common/feign/client/UserFeignClient.java
@@ -1,0 +1,18 @@
+package com.playus.searchservice.domain.common.feign.client;
+
+import com.playus.searchservice.domain.common.feign.fallback.UserFeignFallback;
+import com.playus.searchservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@FeignClient(name = "userFeignClient", url = "${feign.user.url}", path = "/user/api", fallback = UserFeignFallback.class)
+@CircuitBreaker(name = "circuit")
+public interface UserFeignClient {
+
+    @PostMapping("/writers")
+    List<PartyWriterInfoFeignResponse> getWriterInfo(@RequestBody List<Long> writerIdList);
+}

--- a/src/main/java/com/playus/searchservice/domain/common/feign/fallback/UserFeignFallback.java
+++ b/src/main/java/com/playus/searchservice/domain/common/feign/fallback/UserFeignFallback.java
@@ -1,0 +1,19 @@
+package com.playus.searchservice.domain.common.feign.fallback;
+
+import com.playus.searchservice.domain.common.feign.client.UserFeignClient;
+import com.playus.searchservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class UserFeignFallback implements UserFeignClient {
+
+    @Override
+    public List<PartyWriterInfoFeignResponse> getWriterInfo(List<Long> writerIdList) {
+        log.error("503 happened in UserFeignClient at fetching writer data!!!");
+        return List.of(PartyWriterInfoFeignResponse.withServiceUnavailable());
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/common/feign/response/PartyWriterInfoFeignResponse.java
+++ b/src/main/java/com/playus/searchservice/domain/common/feign/response/PartyWriterInfoFeignResponse.java
@@ -1,0 +1,34 @@
+package com.playus.searchservice.domain.common.feign.response;
+
+import lombok.Builder;
+
+@Builder
+public record PartyWriterInfoFeignResponse(
+        Long id,
+        String writerName,
+        String writerGender,
+        int writerAge,
+        String writerThumbnailUrl
+) {
+
+    public static PartyWriterInfoFeignResponse of (Long id, String writerName,
+                                                   String writerGender, int writerAge, String writerThumbnailUrl) {
+        return PartyWriterInfoFeignResponse.builder()
+                .id(id)
+                .writerName(writerName)
+                .writerGender(writerGender)
+                .writerAge(writerAge)
+                .writerThumbnailUrl(writerThumbnailUrl)
+                .build();
+    }
+
+    public static PartyWriterInfoFeignResponse withServiceUnavailable() {
+        return PartyWriterInfoFeignResponse.builder()
+                .id(null)
+                .writerName(null)
+                .writerGender(null)
+                .writerAge(-1)
+                .writerThumbnailUrl(null)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/common/feign/response/PartyWriterInfoFeignResponse.java
+++ b/src/main/java/com/playus/searchservice/domain/common/feign/response/PartyWriterInfoFeignResponse.java
@@ -27,7 +27,7 @@ public record PartyWriterInfoFeignResponse(
                 .id(null)
                 .writerName(null)
                 .writerGender(null)
-                .writerAge(-1)
+                .writerAge(10)
                 .writerThumbnailUrl(null)
                 .build();
     }

--- a/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
+++ b/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
@@ -9,7 +9,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,12 +22,13 @@ public class PostSearchController implements PostSearchControllerSpecification {
     private final PostSearchService postSearchService;
 
     @Override
-    @PostMapping("/posts")
+    @GetMapping("/posts")
     public ResponseEntity<SearchResponse> search(@Valid SearchRequest request) {
         SearchResponse response = postSearchService.search(request);
         return ResponseEntity.ok().body(response);
     }
 
+    @Override
     @GetMapping("/trending")
     public ResponseEntity<List<TrendingKeywordResponse>> getTrendingKeyword() {
         List<TrendingKeywordResponse> response = postSearchService.getTrendingKeyword();

--- a/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
+++ b/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
@@ -1,0 +1,27 @@
+package com.playus.searchservice.domain.post.controller;
+
+import com.playus.searchservice.domain.post.dto.search.SearchRequest;
+import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.service.PostSearchService;
+import com.playus.searchservice.domain.post.specification.PostSearchControllerSpecification;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class PostSearchController implements PostSearchControllerSpecification {
+
+    private final PostSearchService postSearchService;
+
+    @Override
+    @PostMapping("/posts")
+    public ResponseEntity<SearchResponse> search(@Valid SearchRequest request) {
+        SearchResponse response = postSearchService.search(request);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
+++ b/src/main/java/com/playus/searchservice/domain/post/controller/PostSearchController.java
@@ -2,14 +2,18 @@ package com.playus.searchservice.domain.post.controller;
 
 import com.playus.searchservice.domain.post.dto.search.SearchRequest;
 import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse;
 import com.playus.searchservice.domain.post.service.PostSearchService;
 import com.playus.searchservice.domain.post.specification.PostSearchControllerSpecification;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +26,12 @@ public class PostSearchController implements PostSearchControllerSpecification {
     @PostMapping("/posts")
     public ResponseEntity<SearchResponse> search(@Valid SearchRequest request) {
         SearchResponse response = postSearchService.search(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/trending")
+    public ResponseEntity<List<TrendingKeywordResponse>> getTrendingKeyword() {
+        List<TrendingKeywordResponse> response = postSearchService.getTrendingKeyword();
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
@@ -1,6 +1,7 @@
 package com.playus.searchservice.domain.post.document;
 
 import com.playus.searchservice.domain.post.enums.TeamTag;
+import com.playus.searchservice.domain.post.vo.PostSearchResult;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@Setting(settingPath = "/elasticsearch/post-settings.json")
+//@Setting(settingPath = "/elasticsearch/post-settings.json")
 @Document(indexName = "mysql-server.community_dev.post")
 public class PostDocument {
 
@@ -26,22 +27,31 @@ public class PostDocument {
     private String title;
 
     private String description;
+
+    @Field(name = "image_url")
     private String imageUrl;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Keyword, name = "tag")
     private TeamTag tag;
+
     private int view;
 
     @Field(type = FieldType.Boolean)
     private boolean activated;
+
+    @Field(name = "is_secret")
     private boolean isSecret;
 
-    @Field(type = FieldType.Long)
+    @Field(type = FieldType.Long, name = "writer_id")
     private Long writerId;
 
+    @Field(name = "twp_date")
     private LocalDate twpDate;
 
+    @Field(name = "created_at")
     private LocalDateTime createdAt;
+
+    @Field(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Builder
@@ -60,5 +70,13 @@ public class PostDocument {
         this.updatedAt = updatedAt;
     }
 
-
+    public PostSearchResult toPostSearchResult() {
+        return PostSearchResult.builder()
+                .postId(id)
+                .writerId(writerId)
+                .title(title)
+                .thumbnailUrl(imageUrl)
+                .createdAt(createdAt)
+                .build();
+    }
 }

--- a/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
@@ -1,0 +1,64 @@
+package com.playus.searchservice.domain.post.document;
+
+import com.playus.searchservice.domain.post.enums.TeamTag;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Setting(settingPath = "/elasticsearch/post-settings.json")
+@Document(indexName = "mysql-server.community_dev.post")
+public class PostDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    private String description;
+    private String imageUrl;
+
+    @Field(type = FieldType.Keyword)
+    private TeamTag tag;
+    private int view;
+
+    @Field(type = FieldType.Boolean)
+    private boolean activated;
+    private boolean isSecret;
+
+    @Field(type = FieldType.Long)
+    private Long writerId;
+
+    private LocalDate twpDate;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private PostDocument(Long id, String title, String description, String imageUrl, TeamTag tag, int view, boolean activated, boolean isSecret, Long writerId, LocalDate twpDate, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.tag = tag;
+        this.view = view;
+        this.activated = activated;
+        this.isSecret = isSecret;
+        this.writerId = writerId;
+        this.twpDate = twpDate;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+
+}

--- a/src/main/java/com/playus/searchservice/domain/post/dto/search/SearchRequest.java
+++ b/src/main/java/com/playus/searchservice/domain/post/dto/search/SearchRequest.java
@@ -1,0 +1,12 @@
+package com.playus.searchservice.domain.post.dto.search;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SearchRequest(
+
+        @NotBlank(message = "검색어는 필수입니다!")
+        String query
+) {
+}

--- a/src/main/java/com/playus/searchservice/domain/post/dto/search/SearchResponse.java
+++ b/src/main/java/com/playus/searchservice/domain/post/dto/search/SearchResponse.java
@@ -1,0 +1,20 @@
+package com.playus.searchservice.domain.post.dto.search;
+
+import com.playus.searchservice.domain.post.vo.PostSearchResult;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record SearchResponse(
+        int resultSize,
+        List<PostSearchResult> searchResultList
+) {
+
+    public static SearchResponse of (int resultSize, List<PostSearchResult> searchResultList) {
+        return SearchResponse.builder()
+                .resultSize(resultSize)
+                .searchResultList(searchResultList)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/post/dto/trending/TrendingKeywordResponse.java
+++ b/src/main/java/com/playus/searchservice/domain/post/dto/trending/TrendingKeywordResponse.java
@@ -1,0 +1,16 @@
+package com.playus.searchservice.domain.post.dto.trending;
+
+import lombok.Builder;
+
+@Builder
+public record TrendingKeywordResponse(
+      int rank,
+      String keyword
+) {
+    public static TrendingKeywordResponse of (int rank, String keyword) {
+        return TrendingKeywordResponse.builder()
+                .rank(rank)
+                .keyword(keyword)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/post/enums/TeamTag.java
+++ b/src/main/java/com/playus/searchservice/domain/post/enums/TeamTag.java
@@ -1,0 +1,30 @@
+package com.playus.searchservice.domain.post.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamTag {
+    DOOSAN_BEARS("두산 베어스"),
+    HANWHA_EAGLES("한화 이글스"),
+    KIA_TIGERS("KIA 타이거즈"),
+    KIWOOM_HEROES("키움 히어로즈"),
+    LG_TWINS("LG 트윈스"),
+    LOTTE_GIANTS("롯데 자이언츠"),
+    NC_DINOS("NC 다이노스"),
+    SSG_LANDERS("SSG 랜더스"),
+    SAMSUNG_LIONS("삼성 라이온즈"),
+    KT_WIZ("KT 위즈"),;
+
+    private final String teamName;
+
+    public static TeamTag fromString(String name){
+        for (TeamTag teamTag : TeamTag.values()) {
+            if (teamTag.teamName.equals(name)) {
+                return teamTag;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant " + name);
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
+++ b/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
@@ -3,25 +3,23 @@ package com.playus.searchservice.domain.post.service;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import com.playus.searchservice.domain.common.adapter.TrendingKeywordAdapter;
 import com.playus.searchservice.domain.common.feign.client.UserFeignClient;
-import com.playus.searchservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
 import com.playus.searchservice.domain.post.document.PostDocument;
 import com.playus.searchservice.domain.post.dto.search.SearchRequest;
 import com.playus.searchservice.domain.post.dto.search.SearchResponse;
-import com.playus.searchservice.domain.post.vo.PostSearchResult;
+import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,6 +28,7 @@ import java.util.stream.Collectors;
 public class PostSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
+    private final TrendingKeywordAdapter trendingKeywordAdapter;
     private final UserFeignClient userFeignClient;
 
     public SearchResponse search(SearchRequest request) {
@@ -93,5 +92,21 @@ public class PostSearchService {
 //        return SearchResponse.of(resultList.size(), resultList);
 
         return null;
+    }
+
+    public List<TrendingKeywordResponse> getTrendingKeyword() {
+        Set<ZSetOperations.TypedTuple<String>> topKeywords =
+                trendingKeywordAdapter.getTop10Keywords();
+
+        if (topKeywords == null) {
+            return Collections.emptyList();
+        }
+
+        AtomicInteger rank = new AtomicInteger(1);
+        return topKeywords.stream()
+                .map(ZSetOperations.TypedTuple::getValue)
+                .filter(Objects::nonNull)
+                .map(keyword -> TrendingKeywordResponse.of(rank.getAndIncrement(), keyword))
+                .toList();
     }
 }

--- a/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
+++ b/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
@@ -60,7 +60,7 @@ public class PostSearchService {
 
         SearchHits<PostDocument> searchResult = elasticsearchOperations.search(nativeQuery, PostDocument.class);
 
-        increaeTrendingKeyword(query);
+        increaseTrendingKeyword(query);
 
         List<PostSearchResult> resultList = searchResult.getSearchHits().stream()
                 .map(result -> result.getContent().toPostSearchResult())
@@ -119,7 +119,7 @@ public class PostSearchService {
         filters.add(notSecretPostFilter);
     }
 
-    private void increaeTrendingKeyword(String query) {
+    private void increaseTrendingKeyword(String query) {
         if (trendingKeywordAdapter.existsKeyword(query)) {
             trendingKeywordAdapter.scoreKeyword(query);
         } else {

--- a/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
+++ b/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
@@ -3,16 +3,18 @@ package com.playus.searchservice.domain.post.service;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import com.playus.searchservice.domain.common.adapter.TrendingKeywordAdapter;
 import com.playus.searchservice.domain.common.feign.client.UserFeignClient;
+import com.playus.searchservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
 import com.playus.searchservice.domain.post.document.PostDocument;
 import com.playus.searchservice.domain.post.dto.search.SearchRequest;
 import com.playus.searchservice.domain.post.dto.search.SearchResponse;
 import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse;
+import com.playus.searchservice.domain.post.vo.PostSearchResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,30 +36,23 @@ public class PostSearchService {
 
     public SearchResponse search(SearchRequest request) {
 
+        String query = request.query();
+
         Query titleMatchQuery = MatchQuery.of(m -> m
                         .query(request.query())
                         .field("title")
                         .fuzziness("AUTO"))
                 ._toQuery();
 
-//        List<Query> filters = new ArrayList<>();
-//
-//        Query notDeletedPostFilter = TermQuery.of(t -> t
-//                .field("activated")
-//                .value(true)
-//        )._toQuery();
-//        filters.add(notDeletedPostFilter);
-//
-//        Query notSecretPostFilter = TermQuery.of(t -> t
-//                .field("is_secret")
-//                .value(false)
-//        )._toQuery();
-//        filters.add(notSecretPostFilter);
+        List<Query> filters = new ArrayList<>();
+
+        createSoftAndSecretFilter(filters);
 
         Query boolQuery = BoolQuery.of(b -> b
-                        .must(titleMatchQuery))
-//                        .filter(filters))
+                        .must(titleMatchQuery)
+                        .filter(filters))
                 ._toQuery();
+
 
         NativeQuery nativeQuery = NativeQuery.builder()
                 .withQuery(boolQuery)
@@ -64,34 +60,15 @@ public class PostSearchService {
 
         SearchHits<PostDocument> searchResult = elasticsearchOperations.search(nativeQuery, PostDocument.class);
 
-//        List<PostSearchResult> resultList = searchResult.getSearchHits().stream()
-//                .map(SearchHit::getContent)
-//                .toList();
+        increaeTrendingKeyword(query);
 
-        List<SearchHit<PostDocument>> searchHits = searchResult.getSearchHits();
-        System.out.println(searchHits);
+        List<PostSearchResult> resultList = searchResult.getSearchHits().stream()
+                .map(result -> result.getContent().toPostSearchResult())
+                .toList();
 
-//        List<Long> writerIdList = resultList.stream()
-//                .map(PostSearchResult::getWriterId)
-//                .toList();
-//
-//        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIdList);
-//
-//// writerId → writerInfo 맵으로 변환
-//        Map<Long, PartyWriterInfoFeignResponse> writerInfoMap = writerInfoList.stream()
-//                .collect(Collectors.toMap(PartyWriterInfoFeignResponse::id, Function.identity(), (a, b) -> a)); // 중복 ID 있을 경우 첫 번째 유지
-//
-//// 각 PostSearchResult 에 writerName 설정
-//        for (PostSearchResult post : resultList) {
-//            PartyWriterInfoFeignResponse writerInfo = writerInfoMap.get(post.getWriterId());
-//            if (writerInfo != null) {
-//                post.updateWriterName(writerInfo.writerName());
-//            }
-//        }
-//
-//        return SearchResponse.of(resultList.size(), resultList);
+        updateWriterInfo(resultList);
 
-        return null;
+        return SearchResponse.of(resultList.size(), resultList);
     }
 
     public List<TrendingKeywordResponse> getTrendingKeyword() {
@@ -108,5 +85,45 @@ public class PostSearchService {
                 .filter(Objects::nonNull)
                 .map(keyword -> TrendingKeywordResponse.of(rank.getAndIncrement(), keyword))
                 .toList();
+    }
+
+    private void updateWriterInfo(List<PostSearchResult> resultList) {
+        List<Long> writerIdList = resultList.stream()
+                .map(PostSearchResult::getWriterId)
+                .toList();
+
+        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIdList);
+
+        Map<Long, PartyWriterInfoFeignResponse> writerInfoMap = writerInfoList.stream()
+                .collect(Collectors.toMap(PartyWriterInfoFeignResponse::id, Function.identity(), (a, b) -> a)); // 중복 ID 있을 경우 첫 번째 유지
+
+        for (PostSearchResult post : resultList) {
+            PartyWriterInfoFeignResponse writerInfo = writerInfoMap.get(post.getWriterId());
+            if (writerInfo != null) {
+                post.updateWriterName(writerInfo.writerName());
+            }
+        }
+    }
+
+    private static void createSoftAndSecretFilter(List<Query> filters) {
+        Query notDeletedPostFilter = TermQuery.of(t -> t
+                .field("activated")
+                .value(true)
+        )._toQuery();
+        filters.add(notDeletedPostFilter);
+
+        Query notSecretPostFilter = TermQuery.of(t -> t
+                .field("is_secret")
+                .value(false)
+        )._toQuery();
+        filters.add(notSecretPostFilter);
+    }
+
+    private void increaeTrendingKeyword(String query) {
+        if (trendingKeywordAdapter.existsKeyword(query)) {
+            trendingKeywordAdapter.scoreKeyword(query);
+        } else {
+            trendingKeywordAdapter.addKeyword(query);
+        }
     }
 }

--- a/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
+++ b/src/main/java/com/playus/searchservice/domain/post/service/PostSearchService.java
@@ -1,0 +1,97 @@
+package com.playus.searchservice.domain.post.service;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
+import com.playus.searchservice.domain.common.feign.client.UserFeignClient;
+import com.playus.searchservice.domain.common.feign.response.PartyWriterInfoFeignResponse;
+import com.playus.searchservice.domain.post.document.PostDocument;
+import com.playus.searchservice.domain.post.dto.search.SearchRequest;
+import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.vo.PostSearchResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostSearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final UserFeignClient userFeignClient;
+
+    public SearchResponse search(SearchRequest request) {
+
+        Query titleMatchQuery = MatchQuery.of(m -> m
+                        .query(request.query())
+                        .field("title")
+                        .fuzziness("AUTO"))
+                ._toQuery();
+
+//        List<Query> filters = new ArrayList<>();
+//
+//        Query notDeletedPostFilter = TermQuery.of(t -> t
+//                .field("activated")
+//                .value(true)
+//        )._toQuery();
+//        filters.add(notDeletedPostFilter);
+//
+//        Query notSecretPostFilter = TermQuery.of(t -> t
+//                .field("is_secret")
+//                .value(false)
+//        )._toQuery();
+//        filters.add(notSecretPostFilter);
+
+        Query boolQuery = BoolQuery.of(b -> b
+                        .must(titleMatchQuery))
+//                        .filter(filters))
+                ._toQuery();
+
+        NativeQuery nativeQuery = NativeQuery.builder()
+                .withQuery(boolQuery)
+                .build();
+
+        SearchHits<PostDocument> searchResult = elasticsearchOperations.search(nativeQuery, PostDocument.class);
+
+//        List<PostSearchResult> resultList = searchResult.getSearchHits().stream()
+//                .map(SearchHit::getContent)
+//                .toList();
+
+        List<SearchHit<PostDocument>> searchHits = searchResult.getSearchHits();
+        System.out.println(searchHits);
+
+//        List<Long> writerIdList = resultList.stream()
+//                .map(PostSearchResult::getWriterId)
+//                .toList();
+//
+//        List<PartyWriterInfoFeignResponse> writerInfoList = userFeignClient.getWriterInfo(writerIdList);
+//
+//// writerId → writerInfo 맵으로 변환
+//        Map<Long, PartyWriterInfoFeignResponse> writerInfoMap = writerInfoList.stream()
+//                .collect(Collectors.toMap(PartyWriterInfoFeignResponse::id, Function.identity(), (a, b) -> a)); // 중복 ID 있을 경우 첫 번째 유지
+//
+//// 각 PostSearchResult 에 writerName 설정
+//        for (PostSearchResult post : resultList) {
+//            PartyWriterInfoFeignResponse writerInfo = writerInfoMap.get(post.getWriterId());
+//            if (writerInfo != null) {
+//                post.updateWriterName(writerInfo.writerName());
+//            }
+//        }
+//
+//        return SearchResponse.of(resultList.size(), resultList);
+
+        return null;
+    }
+}

--- a/src/main/java/com/playus/searchservice/domain/post/specification/PostSearchControllerSpecification.java
+++ b/src/main/java/com/playus/searchservice/domain/post/specification/PostSearchControllerSpecification.java
@@ -1,0 +1,44 @@
+package com.playus.searchservice.domain.post.specification;
+
+import com.playus.searchservice.domain.post.dto.search.SearchRequest;
+import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+
+public interface PostSearchControllerSpecification {
+
+
+    @Tag(name = "Get", description = "커뮤니티 글 검색 API")
+    @Operation(
+            summary = "커뮤니티 글 검색",
+            description = "커뮤니티 글을 검색합니다.",
+//            security = @SecurityRequirement(name = "Access"),
+            parameters = {
+                    @Parameter(
+                            name = "query",
+                            description = "검색어",
+                            in = ParameterIn.QUERY,
+                            required = true
+                    )
+            }
+    )
+    ResponseEntity<SearchResponse> search(@Valid @Parameter(hidden = true, description = "검색어")
+                                          SearchRequest request);
+
+
+    @Tag(name = "Get", description = "커뮤니티 인기 검색어 조회 API")
+    @Operation(
+            summary = "커뮤니티 인기 검색어 조회",
+            description = "커뮤니티 인기 검색어를 조회합니다."
+//            security = @SecurityRequirement(name = "Access"),
+    )
+    ResponseEntity<List<TrendingKeywordResponse>> getTrendingKeyword();
+}

--- a/src/main/java/com/playus/searchservice/domain/post/vo/PostSearchResult.java
+++ b/src/main/java/com/playus/searchservice/domain/post/vo/PostSearchResult.java
@@ -1,0 +1,45 @@
+package com.playus.searchservice.domain.post.vo;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+public class PostSearchResult {
+
+    private Long postId;
+    private Long writerId;
+    private String writerName;
+    private String title;
+    private String thumbnailUrl;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalDateTime createdAt;
+
+    @Builder
+    private PostSearchResult(Long postId, Long writerId, String writerName, String title, String thumbnailUrl, LocalDateTime createdAt) {
+        this.postId = postId;
+        this.writerId = writerId;
+        this.writerName = writerName;
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.createdAt = createdAt;
+    }
+
+    public static PostSearchResult of(Long postId, String writerName, String title, String thumbnailUrl, LocalDateTime createdAt) {
+        return PostSearchResult.builder()
+                .postId(postId)
+                .writerName(writerName)
+                .title(title)
+                .thumbnailUrl(thumbnailUrl)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    public void updateWriterName(String writerName) {
+        this.writerName = writerName;
+    }
+}

--- a/src/main/java/com/playus/searchservice/global/config/sentry/SentryConfig.java
+++ b/src/main/java/com/playus/searchservice/global/config/sentry/SentryConfig.java
@@ -1,4 +1,4 @@
-package com.playus.searchservice.global.sentry;
+package com.playus.searchservice.global.config.sentry;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/playus/searchservice/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/playus/searchservice/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.playus.searchservice.global.swagger;
+package com.playus.searchservice.global.config.swagger;
 
 import java.util.List;
 

--- a/src/main/java/com/playus/searchservice/global/data/RedisConfig.java
+++ b/src/main/java/com/playus/searchservice/global/data/RedisConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -18,5 +20,17 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean(name = "trendingKeywordRedisTemplate")
+    public RedisTemplate<String, String> trendingKeywordRedisTemplate() {
+
+        RedisTemplate<String, String> trendingKeywordRedisTemplate = new RedisTemplate<>();
+        trendingKeywordRedisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        trendingKeywordRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        trendingKeywordRedisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return trendingKeywordRedisTemplate;
     }
 }

--- a/src/main/java/com/playus/searchservice/global/data/RedisConfig.java
+++ b/src/main/java/com/playus/searchservice/global/data/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.playus.searchservice.global.data;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/playus/searchservice/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/playus/searchservice/global/exception/ExceptionAdvice.java
@@ -1,0 +1,26 @@
+package com.playus.searchservice.global.exception;
+
+import com.playus.searchservice.domain.post.controller.PostSearchController;
+import com.playus.searchservice.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@RestControllerAdvice(assignableTypes = {
+        PostSearchController.class
+})
+public class ExceptionAdvice {
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ErrorResponse handleBindException(BindException e) {
+        String errorMessage = e.getAllErrors().get(0).getDefaultMessage();
+        log.warn("Validation Error: {}", errorMessage);
+        return ErrorResponse.badRequestError(errorMessage);
+    }
+}

--- a/src/main/java/com/playus/searchservice/global/response/ErrorResponse.java
+++ b/src/main/java/com/playus/searchservice/global/response/ErrorResponse.java
@@ -1,0 +1,44 @@
+package com.playus.searchservice.global.response;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ErrorResponse(
+        int code,
+        HttpStatus status,
+        String message
+) {
+
+    public static ErrorResponse badRequestError (String errorMessage) {
+        return createErrorResponse(HttpStatus.BAD_REQUEST, errorMessage);
+    }
+
+    public static ErrorResponse unauthorizedError (String errorMessage) {
+        return createErrorResponse(HttpStatus.UNAUTHORIZED, errorMessage);
+    }
+
+    public static ErrorResponse forbiddenError (String errorMessage) {
+        return createErrorResponse(HttpStatus.FORBIDDEN, errorMessage);
+    }
+
+    public static ErrorResponse notFoundError(String errorMessage) {
+        return createErrorResponse(HttpStatus.NOT_FOUND, errorMessage);
+    }
+
+    public static ErrorResponse conflictError(String errorMessage) {
+        return createErrorResponse(HttpStatus.CONFLICT, errorMessage);
+    }
+
+    public static ErrorResponse internalServerError (String errorMessage) {
+        return createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
+    }
+
+    private static ErrorResponse createErrorResponse(HttpStatus errorStatus, String errorMessage) {
+        return ErrorResponse.builder()
+                .code(errorStatus.value())
+                .status(errorStatus)
+                .message(errorMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/playus/searchservice/global/sentry/SentryConfig.java
+++ b/src/main/java/com/playus/searchservice/global/sentry/SentryConfig.java
@@ -5,8 +5,10 @@ import org.springframework.context.annotation.Configuration;
 
 import io.sentry.Sentry;
 import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile({"prod", "dev"})
 public class SentryConfig {
 
 	@Value("${sentry.dsn}")

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -23,6 +23,27 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
 
+feign:
+  user:
+    url: ${USER_SERVICE_URL}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      circuit:
+        base-config: default
+
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,6 +6,11 @@ spring:
     elasticsearch:
       repositories:
         enabled: true
+
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   elasticsearch:
     uris: ${SPRING_ELASTIC_SEARCH_URL}
 
@@ -27,8 +32,11 @@ management:
       exposure:
         include:
           - health           # 애플리케이션 상태 확인
+          - info             # 애플리케이션 정보
           - prometheus       # 메트릭 데이터 노출
 
   endpoint:
     health:
-      show-details: never
+      show-details: always
+
+

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -23,6 +23,27 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
 
+feign:
+  user:
+    url: http://localhost:8080
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      circuit:
+        base-config: default
+
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,6 +6,11 @@ spring:
     elasticsearch:
       repositories:
         enabled: true
+
+    redis:
+      host: localhost
+      port: 6379
+
   elasticsearch:
     uris: ${SPRING_ELASTIC_SEARCH_URL}
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -6,6 +6,11 @@ spring:
     elasticsearch:
       repositories:
         enabled: true
+
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   elasticsearch:
     uris: ${SPRING_ELASTIC_SEARCH_URL}
 
@@ -20,3 +25,22 @@ logging:
 
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health           # 애플리케이션 상태 확인
+          - info             # 애플리케이션 정보
+          - prometheus       # 메트릭 데이터 노출
+
+  endpoint:
+    health:
+      show-details: always
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -23,6 +23,27 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
 
+feign:
+  user:
+    url: ${USER_SERVICE_URL}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 50
+        slow-call-rate-threshold: 80
+        slow-call-duration-threshold: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        max-wait-duration-in-half-open-state: 0s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 10s
+    instances:
+      circuit:
+        base-config: default
+
 slack:
   webhook-url: ${SLACK_WEBHOOK_URL}
 
@@ -38,9 +59,3 @@ management:
   endpoint:
     health:
       show-details: always
-
-springdoc:
-  swagger-ui:
-    enabled: false
-  api-docs:
-    enabled: false

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,3 +1,8 @@
+spring:
+  data:
+    elasticsearch:
+      repositories:
+        enabled: true
 
 logging:
   level:

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,0 +1,4 @@
+
+logging:
+  level:
+    org.elasticsearch.client: TRACE

--- a/src/test/java/com/playus/searchservice/ControllerTestSupport.java
+++ b/src/test/java/com/playus/searchservice/ControllerTestSupport.java
@@ -1,0 +1,26 @@
+package com.playus.searchservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playus.searchservice.domain.post.controller.PostSearchController;
+import com.playus.searchservice.domain.post.service.PostSearchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = {
+        PostSearchController.class
+})
+public abstract class ControllerTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockitoBean
+    protected PostSearchService postSearchService;
+}

--- a/src/test/java/com/playus/searchservice/IntegrationTestSupport.java
+++ b/src/test/java/com/playus/searchservice/IntegrationTestSupport.java
@@ -1,0 +1,45 @@
+package com.playus.searchservice;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+
+    private static final GenericContainer redis;
+    private static final ElasticsearchContainer elasticsearch;
+
+    private static final String REDIS_VERSION = "redis:7.0.12";
+    private static final String ELASTIC_VERSION = "elasticsearch:9.0.1";
+
+    private static final int REDIS_PORT = 6379;
+    private static final int ELASTIC_PORT = 9200;
+
+    static {
+        redis = new GenericContainer(DockerImageName.parse(REDIS_VERSION))
+                .withExposedPorts(REDIS_PORT)
+                .withReuse(true);
+
+        elasticsearch = new ElasticsearchContainer(DockerImageName.parse(ELASTIC_VERSION))
+                .withExposedPorts(ELASTIC_PORT)
+                .withReuse(true);
+
+        redis.start();
+        elasticsearch.start();
+    }
+
+    @DynamicPropertySource
+    public static void dynamicConfiguration(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> String.valueOf(redis.getMappedPort(REDIS_PORT)));
+
+        registry.add("spring.elasticsearch.uris", () -> String.format("http://%s:%d/", elasticsearch.getHost(), elasticsearch.getMappedPort(ELASTIC_PORT)));
+    }
+}
+

--- a/src/test/java/com/playus/searchservice/domain/common/adapter/TrendingKeywordAdapterTest.java
+++ b/src/test/java/com/playus/searchservice/domain/common/adapter/TrendingKeywordAdapterTest.java
@@ -1,0 +1,113 @@
+package com.playus.searchservice.domain.common.adapter;
+
+import com.playus.searchservice.IntegrationTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrendingKeywordAdapterTest extends IntegrationTestSupport {
+
+    private static final String KEY_NAME = "TRENDING-KEYWORD";
+
+    @Autowired
+    private TrendingKeywordAdapter trendingKeywordAdapter;
+
+    @Autowired
+    private RedisTemplate<String, String> trendingKeywordRedisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        trendingKeywordRedisTemplate.delete(KEY_NAME);
+    }
+
+    @Test
+    @DisplayName("새로운 키워드를 추가할 수 있다")
+    void addKeyword_success() {
+        // given
+        String keyword = "springboot";
+
+        // when
+        Boolean result = trendingKeywordAdapter.addKeyword(keyword);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("기존 키워드의 점수를 증가시킬 수 있다")
+    void scoreKeyword_success() {
+        // given
+        String keyword = "springboot";
+        trendingKeywordAdapter.addKeyword(keyword);
+
+        // when
+        Double score = trendingKeywordAdapter.scoreKeyword(keyword);
+
+        // then
+        assertThat(score).isEqualTo(2.0);
+    }
+
+    @DisplayName("특정 키워드가 검색된 적 있는지 확인할 수 있다.")
+    @Test
+    void existsKeyword() {
+        // given
+        trendingKeywordAdapter.addKeyword("spring");
+
+        // when
+        Boolean result = trendingKeywordAdapter.existsKeyword("spring");
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("특정 키워드가 검색된 적 없을 수 있다.")
+    @Test
+    void existsKeyword_NOT_EXISTS() {
+      // given
+
+        // when
+        Boolean result = trendingKeywordAdapter.existsKeyword("spring");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("상위 10개의 키워드를 순위와 함께 조회할 수 있다")
+    void getTop10Keywords_success() {
+        // given
+        trendingKeywordAdapter.addKeyword("spring"); // 1
+        trendingKeywordAdapter.addKeyword("java");   // 1
+        trendingKeywordAdapter.addKeyword("redis");  // 1
+
+        trendingKeywordAdapter.scoreKeyword("spring"); // 2
+        trendingKeywordAdapter.scoreKeyword("spring"); // 3
+
+        // when
+        Set<ZSetOperations.TypedTuple<String>> topKeywords = trendingKeywordAdapter.getTop10Keywords();
+
+        // then
+        assertThat(topKeywords).hasSize(3);
+
+        List<ZSetOperations.TypedTuple<String>> resultList = new ArrayList<>(topKeywords);
+
+        assertThat(resultList.get(0).getValue()).isEqualTo("spring");
+        assertThat(resultList.get(0).getScore()).isEqualTo(3.0);
+
+        // 나머지 키워드들도 존재하는지만 확인
+        List<String> keywords = resultList.stream()
+                .map(ZSetOperations.TypedTuple::getValue)
+                .toList();
+
+        assertThat(keywords).contains("java", "redis");
+    }
+}

--- a/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,7 +35,7 @@ class PostSearchControllerTest extends ControllerTestSupport {
         given(postSearchService.search(any(SearchRequest.class))).willReturn(response);
 
         // when // then
-        mockMvc.perform(post("/search/posts")
+        mockMvc.perform(get("/search/posts")
                         .param("query", query)
                         .contentType(APPLICATION_JSON))
                 .andDo(print())
@@ -54,7 +55,7 @@ class PostSearchControllerTest extends ControllerTestSupport {
         // given
 
         // when // then
-        mockMvc.perform(post("/search/posts")
+        mockMvc.perform(get("/search/posts")
                         .param("query", emptyQuery)
                         .contentType(APPLICATION_JSON))
                 .andDo(print())

--- a/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
@@ -1,0 +1,67 @@
+package com.playus.searchservice.domain.post.controller;
+
+import com.playus.searchservice.ControllerTestSupport;
+import com.playus.searchservice.domain.post.dto.search.SearchRequest;
+import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.vo.PostSearchResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PostSearchControllerTest extends ControllerTestSupport {
+
+    @DisplayName("커뮤니티 게시글을 검색할 수 있다.")
+    @Test
+    void search() throws Exception {
+        // given
+        String query = "테스트";
+        List<PostSearchResult> searchResultList = List.of(
+                PostSearchResult.of(1L, "kim", "title", "http://thumbnailUrl", LocalDateTime.of(2025, 5, 25, 10, 0, 0))
+        );
+        SearchResponse response = SearchResponse.of(1, searchResultList);
+        given(postSearchService.search(any(SearchRequest.class))).willReturn(response);
+
+        // when // then
+        mockMvc.perform(post("/search/posts")
+                        .param("query", query)
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultSize").value(1))
+                .andExpect(jsonPath("$.searchResultList[0].postId").value(1L))
+                .andExpect(jsonPath("$.searchResultList[0].writerName").value("kim"))
+                .andExpect(jsonPath("$.searchResultList[0].title").value("title"))
+                .andExpect(jsonPath("$.searchResultList[0].thumbnailUrl").value("http://thumbnailUrl"))
+                .andExpect(jsonPath("$.searchResultList[0].createdAt").value("10:00"));
+    }
+
+    @DisplayName("게시글 검색 시 검색어는 필수이다.")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void search_EMPTY_QUERY(String emptyQuery) throws Exception {
+        // given
+
+        // when // then
+        mockMvc.perform(post("/search/posts")
+                        .param("query", emptyQuery)
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("검색어는 필수입니다!"));
+    }
+}
+

--- a/src/test/java/com/playus/searchservice/domain/post/service/PostSearchServiceTest.java
+++ b/src/test/java/com/playus/searchservice/domain/post/service/PostSearchServiceTest.java
@@ -61,7 +61,7 @@ class PostSearchServiceTest extends IntegrationTestSupport {
 
     @DisplayName("검색 기록이 없을 수 있다.")
     @Test
-    void getTrendingKeyword_EMPYT() {
+    void getTrendingKeyword_EMPTY() {
         // given
 
         // when

--- a/src/test/java/com/playus/searchservice/domain/post/service/PostSearchServiceTest.java
+++ b/src/test/java/com/playus/searchservice/domain/post/service/PostSearchServiceTest.java
@@ -1,0 +1,74 @@
+package com.playus.searchservice.domain.post.service;
+
+import com.playus.searchservice.IntegrationTestSupport;
+import com.playus.searchservice.domain.common.adapter.TrendingKeywordAdapter;
+import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class PostSearchServiceTest extends IntegrationTestSupport {
+
+    private static final String KEY_NAME = "TRENDING-KEYWORD";
+
+    @Autowired
+    private PostSearchService postSearchService;
+
+    @Autowired
+    private RedisTemplate<String, String> trendingKeywordRedisTemplate;
+
+    @Autowired
+    private TrendingKeywordAdapter trendingKeywordAdapter;
+
+    @AfterEach
+    void tearDown() {
+        trendingKeywordRedisTemplate.delete(KEY_NAME);
+    }
+
+    @DisplayName("10등까지의 실시간 검색어를 가져올 수 있다.")
+    @Test
+    void getTrendingKeyword() {
+
+        // given
+        trendingKeywordAdapter.addKeyword("spring"); // 1
+        trendingKeywordAdapter.scoreKeyword("spring");
+        trendingKeywordAdapter.scoreKeyword("spring");
+
+        trendingKeywordAdapter.addKeyword("java");   // 2
+        trendingKeywordAdapter.scoreKeyword("java");
+
+        trendingKeywordAdapter.addKeyword("redis");  // 3
+
+        // when
+        List<TrendingKeywordResponse> result = postSearchService.getTrendingKeyword();
+
+        // then
+        assertThat(result).hasSize(3)
+                .extracting("rank", "keyword")
+                .containsExactlyInAnyOrder(
+                        tuple(1, "spring"),
+                        tuple(2, "java"),
+                        tuple(3, "redis")
+                );
+    }
+
+    @DisplayName("검색 기록이 없을 수 있다.")
+    @Test
+    void getTrendingKeyword_EMPYT() {
+        // given
+
+        // when
+        List<TrendingKeywordResponse> result = postSearchService.getTrendingKeyword();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

타이틀 기반 검색, 인기 검색어 기능 구현했습니다. 
지금 Elasticsearch 에 nori 가 적용되어 잇지 않아서 그런지 한글이 섞인 문장 대해서는 특정 단어에 대한 검색은 안 되고 잇습니다. 코드는 변경될 거 같지 않아서 일단 pr 올립니다. db 쪽 해결되면 추후 다른 분들께도 review 요청하겟습니다

---

## 🔗 관련 이슈
- closes #18 

---

## 💡 추가 사항
dev, prod profile 동기화했습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 커뮤니티 게시글 검색 API 및 인기 검색어 조회 API가 추가되었습니다.
  - 게시글 검색 시 Elasticsearch 기반의 검색 결과와 함께 작성자 정보가 제공됩니다.
  - 인기 검색어 상위 10개를 확인할 수 있습니다.
  - 검색어 입력값 검증 및 오류 응답이 표준화되었습니다.
  - Redis를 활용한 인기 검색어 관리 기능이 도입되었습니다.
  - Feign 클라이언트와 Resilience4j 회로 차단기 도입으로 외부 사용자 서비스 연동이 강화되었습니다.

- **버그 수정**
  - 검색어가 비어 있을 경우 400 Bad Request와 함께 명확한 에러 메시지가 반환됩니다.

- **문서화**
  - OpenAPI 명세에 검색 및 인기 검색어 관련 엔드포인트가 추가되었습니다.

- **테스트**
  - 검색 API, 인기 검색어, Redis 연동 등 주요 기능에 대한 단위 및 통합 테스트가 추가되었습니다.

- **환경설정**
  - Redis, Feign, Resilience4j, Testcontainers 등 외부 서비스 연동 및 테스트 환경 구성이 추가되었습니다.
  - Sentry, Swagger 등 일부 설정이 환경별로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->