### PR TITLE
CS-375 SecurityConfig 내 whiteList 내 /health, /actuator 뒤 와일드카드 추가

### DIFF
--- a/src/main/java/com/playus/searchservice/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/playus/searchservice/global/config/security/SecurityConfig.java
@@ -1,8 +1,6 @@
 package com.playus.searchservice.global.config.security;
 
-import com.playus.searchservice.domain.common.feign.client.UserFeignClient;
 import com.playus.searchservice.global.jwt.JwtFilter;
-import com.playus.searchservice.global.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,8 +23,8 @@ public class SecurityConfig {
     private String [] getWhiteList() {
         return new String[] {
                 "/error",
-                "/health",
-                "/actuator",
+                "/health/**",
+                "/actuator/**",
                 "/swagger",
                 "/swagger-ui.html",
                 "/swagger-ui/**",


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
`SecurityConfig` 내 /health, /actuator 뒤에 와일드카드 추가햇습니다

---

## 🔗 관련 이슈
- closes #22 
---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - `/health` 및 `/actuator` 경로의 접근 허용 범위가 모든 하위 경로(`/health/**`, `/actuator/**`)로 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->