### PR TITLE
CS-386 refactor/검색 response에 team tag 추가

### DIFF
--- a/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
+++ b/src/main/java/com/playus/searchservice/domain/post/document/PostDocument.java
@@ -74,6 +74,7 @@ public class PostDocument {
                 .writerId(writerId)
                 .title(title)
                 .thumbnailUrl(imageUrl)
+                .teamTag(tag)
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/main/java/com/playus/searchservice/domain/post/specification/PostSearchControllerSpecification.java
+++ b/src/main/java/com/playus/searchservice/domain/post/specification/PostSearchControllerSpecification.java
@@ -6,12 +6,18 @@ import com.playus.searchservice.domain.post.dto.trending.TrendingKeywordResponse
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 
 public interface PostSearchControllerSpecification {
@@ -38,6 +44,49 @@ public interface PostSearchControllerSpecification {
                     )
             }
     )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "검색 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "검색 응답 예시",
+                                    value = """
+                                            {
+                                                 "resultSize": 1,
+                                                 "searchResultList": [
+                                                     {
+                                                         "postId": 71,
+                                                         "writerId": 2,
+                                                         "writerName": null,
+                                                         "title": "LG가 좋아요",
+                                                         "thumbnailUrl": "post.jpg",
+                                                         "teamTag": "DOOSAN_BEARS",
+                                                         "createdAt": "11:42"
+                                                     }
+                                                 ]
+                                             }
+                                            """
+                            )
+                    )
+            ),
+
+            @ApiResponse(
+                    responseCode = "400", description = "검색 시도 시 검색어가 비어 있을 때 발생",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": 400,
+                                              "status": "BAD_REQUEST",
+                                              "message": "검색어는 필수입니다!"
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     ResponseEntity<SearchResponse> search(@Valid @Parameter(hidden = true, description = "검색어")
                                           SearchRequest request);
 
@@ -57,5 +106,60 @@ public interface PostSearchControllerSpecification {
                     )
             }
     )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200", description = "인기 검색어 조회 성공",
+                    content = @Content(
+                            mediaType = APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(
+                                    name = "인기 검색어 응답 예시",
+                                    value = """
+                                            [
+                                                  {
+                                                      "rank": 1,
+                                                      "keyword": "LG"
+                                                  },
+                                                  {
+                                                      "rank": 2,
+                                                      "keyword": "NC"
+                                                  },
+                                                  {
+                                                      "rank": 3,
+                                                      "keyword": "NC가"
+                                                  },
+                                                  {
+                                                      "rank": 4,
+                                                      "keyword": "삼성"
+                                                  },
+                                                  {
+                                                      "rank": 5,
+                                                      "keyword": "사과"
+                                                  },
+                                                  {
+                                                      "rank": 6,
+                                                      "keyword": "lg"
+                                                  },
+                                                  {
+                                                      "rank": 7,
+                                                      "keyword": "테스트"
+                                                  },
+                                                  {
+                                                      "rank": 8,
+                                                      "keyword": "test"
+                                                  },
+                                                  {
+                                                      "rank": 9,
+                                                      "keyword": "nc"
+                                                  },
+                                                  {
+                                                      "rank": 10,
+                                                      "keyword": "text"
+                                                  }
+                                              ]
+                                            """
+                            )
+                    )
+            )
+    })
     ResponseEntity<List<TrendingKeywordResponse>> getTrendingKeyword();
 }

--- a/src/main/java/com/playus/searchservice/domain/post/vo/PostSearchResult.java
+++ b/src/main/java/com/playus/searchservice/domain/post/vo/PostSearchResult.java
@@ -1,6 +1,7 @@
 package com.playus.searchservice.domain.post.vo;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.playus.searchservice.domain.post.enums.TeamTag;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,26 +16,29 @@ public class PostSearchResult {
     private String writerName;
     private String title;
     private String thumbnailUrl;
+    private TeamTag teamTag;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalDateTime createdAt;
 
     @Builder
-    private PostSearchResult(Long postId, Long writerId, String writerName, String title, String thumbnailUrl, LocalDateTime createdAt) {
+    private PostSearchResult(Long postId, Long writerId, String writerName, String title, String thumbnailUrl, TeamTag teamTag, LocalDateTime createdAt) {
         this.postId = postId;
         this.writerId = writerId;
         this.writerName = writerName;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
+        this.teamTag = teamTag;
         this.createdAt = createdAt;
     }
 
-    public static PostSearchResult of(Long postId, String writerName, String title, String thumbnailUrl, LocalDateTime createdAt) {
+    public static PostSearchResult of(Long postId, String writerName, String title, String thumbnailUrl, TeamTag teamTag, LocalDateTime createdAt) {
         return PostSearchResult.builder()
                 .postId(postId)
                 .writerName(writerName)
                 .title(title)
                 .thumbnailUrl(thumbnailUrl)
+                .teamTag(teamTag)
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/playus/searchservice/domain/post/controller/PostSearchControllerTest.java
@@ -5,6 +5,7 @@ import com.playus.searchservice.domain.common.security.CustomOAuth2User;
 import com.playus.searchservice.domain.common.security.Role;
 import com.playus.searchservice.domain.post.dto.search.SearchRequest;
 import com.playus.searchservice.domain.post.dto.search.SearchResponse;
+import com.playus.searchservice.domain.post.enums.TeamTag;
 import com.playus.searchservice.domain.post.vo.PostSearchResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,7 +55,7 @@ class PostSearchControllerTest extends ControllerTestSupport {
         // given
         String query = "테스트";
         List<PostSearchResult> searchResultList = List.of(
-                PostSearchResult.of(1L, "kim", "title", "http://thumbnailUrl", LocalDateTime.of(2025, 5, 25, 10, 0, 0))
+                PostSearchResult.of(1L, "kim", "title", "http://thumbnailUrl", TeamTag.DOOSAN_BEARS, LocalDateTime.of(2025, 5, 25, 10, 0, 0))
         );
         SearchResponse response = SearchResponse.of(1, searchResultList);
         given(postSearchService.search(any(SearchRequest.class))).willReturn(response);
@@ -71,6 +72,7 @@ class PostSearchControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.searchResultList[0].writerName").value("kim"))
                 .andExpect(jsonPath("$.searchResultList[0].title").value("title"))
                 .andExpect(jsonPath("$.searchResultList[0].thumbnailUrl").value("http://thumbnailUrl"))
+                .andExpect(jsonPath("$.searchResultList[0].teamTag").value("DOOSAN_BEARS"))
                 .andExpect(jsonPath("$.searchResultList[0].createdAt").value("10:00"));
     }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
검색 결과에 `teamTag` 가 추가됩니다

![image](https://github.com/user-attachments/assets/1817db40-0477-4109-a969-1592dbef0590)


---

## 🔗 관련 이슈
- closes #28 

---

## 💡 추가 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 검색 결과에 팀 태그(teamTag) 정보가 추가되어, 검색 시 각 게시글의 팀 태그를 확인할 수 있습니다.

- **문서화**
  - 검색 및 트렌드 키워드 API의 응답 예시와 설명이 API 문서에 추가되어, 응답 구조를 더 명확히 확인할 수 있습니다.

- **테스트**
  - 검색 결과에 팀 태그가 포함되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->